### PR TITLE
Make wayfire-kbdd-plugin readily usable on wayfire version distributed with Raspberry PI OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ sudo ninja -C build install
 ```
 This will install to `/usr/local/`. To install in `/usr`  you can use  the option: `meson build --prefix=/usr`.
 
-For RPI's wayfire version (0.7.5) checkout tag 0.4.5 (`git tag 0.4.5`) before building
+For RPI's wayfire version (0.7.5) checkout tag 0.4.5 (`git checkout 0.4.5`) before building

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ ninja -C build
 sudo ninja -C build install
 ```
 This will install to `/usr/local/`. To install in `/usr`  you can use  the option: `meson build --prefix=/usr`.
+
+For RPI's wayfire version (0.7.5) checkout tag 0.4.5 (`git tag 0.4.5`) before building

--- a/src/kbdd.cpp
+++ b/src/kbdd.cpp
@@ -62,8 +62,7 @@ class kbdd_plugin : public wf::plugin_interface_t
 
     wf::signal_connection_t keyboard_focus_changed = [=] (wf::signal_data_t *data) {
         wf::keyboard_focus_changed_signal *signal = static_cast<wf::keyboard_focus_changed_signal*>(data);
-        wf::scene::node_ptr focused_node = signal->new_focus;
-        wayfire_view view = wf::node_to_view(focused_node);
+        wayfire_view view = signal->view;
 
         if (!view)
             return;


### PR DESCRIPTION
Created an interim tag (0.4.5) between 0.4 and 0.5 that can be compiled (and has been tested and works) against wayfire version 0.7.5, which is the one currently distributed with Raspberry Pi OS.